### PR TITLE
Accept the system-err child element of a testcase.

### DIFF
--- a/nosepicker/parser.py
+++ b/nosepicker/parser.py
@@ -170,7 +170,7 @@ class NoseTestCase(object):
         self.failures = [NoseTestError(self,node) for node in self.node.xpath('failure')]
 
         for node in self.node:
-            if node.tag not in ('error','failure','skipped'):
+            if node.tag not in ('error','failure','skipped','system-err'):
                 self.log.debug('UNEXPECTED: %s' % ET.tostring(node))
                 raise ValueError('Unexpected testcase child element: %s' % node.tag)
 


### PR DESCRIPTION
The system-err holds warnings, like the RunTimeWarning about naive and
aware datetimes.